### PR TITLE
Fix: Error build on Windows: could not find `unix` in `os`

### DIFF
--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -70,10 +70,22 @@ pub(crate) fn build_obfuscation_mod(
 
 /// Creates the inports for the `muddy_internal` mod
 fn build_obfuscation_imports() -> proc_macro2::TokenStream {
+    #[cfg(unix)]
+    let use_os_str_ext = quote! {
+        use std::os::unix::ffi::OsStrExt;
+    };
+    #[cfg(target_os = "wasi")]
+    let use_os_str_ext = quote! {
+        use std::os::wasi::ffi::OsStrExt;
+    };
+    #[cfg(windows)]
+    let use_os_str_ext = quote! {
+        use std::os::windows::ffi::OsStrExt;
+    };
     quote! {
         use muddy::{GenericArray, KeyInit, Lazy, ChaCha20Poly1305, Key, Aead, U32, Nonce};
         pub use muddy::{LazyStr, FromHex};
-        use std::os::unix::ffi::OsStrExt;
+        #use_os_str_ext
     }
 }
 


### PR DESCRIPTION
Hello @orph3usLyre.

Fix: added OS-based conditional import for the `OsStrExt` trait in the `build_obfuscation_imports()` function.

Fixes https://github.com/orph3usLyre/muddy-waters/issues/2

Best wishes,
Sergey.