### PR TITLE
Fix: env variable decoding and added error messages

### DIFF
--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -117,8 +117,7 @@ fn build_env_cipher_block(
             let Some(var) = std::env::var_os(#env_ident) else {
                 panic!()
             };
-            let Ok(bytes) = <[u8; 32]>::from_hex(var.as_bytes()) else {
-                panic!()
+            let Ok(bytes) = <[u8; 32]>::from_hex(var.as_encoded_bytes()) else {
             };
 
             Key::clone_from_slice(&bytes)

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -42,7 +42,14 @@ pub(crate) fn build_obfuscation_mod(
                 Some(ref s) => s.as_str(),
                 _ => "MUDDY",
             };
-            eprintln!("{env_name}='{key}'");
+            eprintln!("Please, set {env_name} env variable with content:\n");
+            #[cfg(windows)]
+            // language=cmd
+            eprintln!(r#"set "{env_name}={key}""#);
+            #[cfg(not(windows))]
+            // language=sh
+            eprintln!(r#"{env_name}="{key}""#);
+            eprintln!();
             build_env_cipher_block(key_ident, cipher_ident, env_name)
         }
     };

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -122,10 +122,16 @@ fn build_env_cipher_block(
     quote! {
         static #key_ident: Lazy<Key> = Lazy::new(|| {
             let Some(var) = std::env::var_os(#env_ident) else {
+                #[cfg(debug_assertions)]
                 panic!("Need to set {} env variable", #env_ident);
+                #[cfg(not(debug_assertions))]
+                panic!();
             };
             let Ok(bytes) = <[u8; 32]>::from_hex(var.as_encoded_bytes()) else {
-                panic!("Can't get bytes from {} env variable, secret key needs to be a hex string with 64 symbols length.", #env_ident)
+                #[cfg(debug_assertions)]
+                panic!("Can't get bytes from {} env variable, secret key needs to be a hex string with 64 symbols length.", #env_ident);
+                #[cfg(not(debug_assertions))]
+                panic!();
             };
 
             Key::clone_from_slice(&bytes)

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -49,7 +49,6 @@ pub(crate) fn build_obfuscation_mod(
             #[cfg(not(windows))]
             // language=sh
             eprintln!(r#"{env_name}="{key}""#);
-            eprintln!();
             build_env_cipher_block(key_ident, cipher_ident, env_name)
         }
     };

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -42,7 +42,7 @@ pub(crate) fn build_obfuscation_mod(
                 Some(ref s) => s.as_str(),
                 _ => "MUDDY",
             };
-            eprintln!("Please, set {env_name} env variable with content:\n");
+            eprintln!("Please, set {env_name} env variable with content:");
             #[cfg(windows)]
             // language=cmd
             eprintln!(r#"set "{env_name}={key}""#);

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -115,9 +115,10 @@ fn build_env_cipher_block(
     quote! {
         static #key_ident: Lazy<Key> = Lazy::new(|| {
             let Some(var) = std::env::var_os(#env_ident) else {
-                panic!()
+                panic!("Need to set {} env variable", #env_ident);
             };
             let Ok(bytes) = <[u8; 32]>::from_hex(var.as_encoded_bytes()) else {
+                panic!("Can't get bytes from {} env variable, secret key needs to be a hex string with 64 symbols length.", #env_ident)
             };
 
             Key::clone_from_slice(&bytes)


### PR DESCRIPTION
Hello @orph3usLyre.

Fix for an error:

> no method named `as_bytes` found for struct `OsString` in the current scope [E0599] 

https://github.com/orph3usLyre/muddy-waters/blob/5f73dc10d65087f933a2c5fb7f5d490850917643/muddy_macros/src/internal.rs#L120

As far as I know, it's Windows related problem, because the `OsStrExt` trait on Windows https://doc.rust-lang.org/std/os/windows/ffi/trait.OsStrExt.html is missing `as_bytes()` function.

Related: https://github.com/orph3usLyre/muddy-waters/issues/2 and https://github.com/orph3usLyre/muddy-waters/pull/3.

## Changes

* Fix: using `var.as_encoded_bytes()` instead of `var.as_bytes()` in the `build_env_cipher_block()` function.
* Added panic messages in the `build_env_cipher_block()` function.
* Added cross-platform information how to set env variables in the `build_obfuscation_mod()` function.


Best wishes,
Sergey.