### PR TITLE
[`chore`] fix doc tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 * add `pull_request.yml` to check for added `CHANGELOG.md` entries on pull requests (#8)
 * add `rust.yml` to run `cargo fmt`, `clippy`, `rustdoc`, and `test` for pull requests or pushes on `main` (#8)
+* fix doc tests in `muddy` & ignore all doc tests in `muddy_macros` (not functional without `muddy`)
 
 ## 0.2.0
 * Initial published crate version

--- a/muddy/src/lib.rs
+++ b/muddy/src/lib.rs
@@ -9,16 +9,13 @@
 //! ## Usage & Examples
 //!
 //! ```rust
-//!
-//! extern crate muddy;
 //! use muddy::{m, muddy_init};
 //!
 //! muddy_init!();
 //!
-//! fn main() {
-//!     println!("{}", m!("My highly obfuscated text"));
-//!     println!("{}", "My non obfuscated static str - ripgrep me");
-//! }
+//! println!("{}", m!("My highly obfuscated text"));
+//! println!("{}", "My non obfuscated static str - ripgrep me");
+//!
 //! ```  
 //!     
 //!    
@@ -39,24 +36,41 @@
 //! These macros can be used as an in-place text replacement with `m!("my text")`:
 //!
 //! ```rust
+//! use muddy::{muddy_init, m};
+//!
+//! muddy_init!();
+//!
 //! println!("{}", m!("my plaintext"));
 //! ```  
 //!
 //! As an annotated `&'static str` with the [`muddy`] attribute:
 //!
 //! ```rust
+//! #[macro_use] extern crate muddy;
+//! use muddy::{muddy, muddy_init};
+//!
+//! muddy_init!();
+//!
 //! #[muddy]
 //! static MY_STR: &str = "my plaintext";
+//!
+//! # fn main() {}
 //! ```
 //!
 //! Or as an invocation around multiple annotated `&'static str`s with [`muddy_all`]:
 //!
 //! ```rust
+//! use muddy::{muddy_all, muddy_init};
+//!
+//! muddy_init!();
+//!
 //! muddy_all! {
 //!    pub static MY_STR: &str = "my plaintext";
 //!    pub static MY_SECOND_STR: &str = "my second plaintext";
 //!    static MY_THIRD_STR: &str = "my module-specific third plaintext";
 //! }
+//!
+//! # fn main() {}
 //! ```
 //!
 //! By default, `muddy` will encrypt the static strings with the [`chacha20poly1305`] implementation,
@@ -64,9 +78,9 @@
 //!
 //! To avoid hardcoding the deobfuscation key into your binary, you may use:
 //!
-//! ```rust
+//! // NOTE: this test will fail if run by tests since the key needs to be provided at runtime
+//! ```rust,no_run
 //!
-//! extern crate muddy;
 //! use muddy::{m, muddy_init};
 //!
 //! muddy_init!("env");
@@ -78,11 +92,10 @@
 //!
 //! // This key needs to be provided at runtime else the program will panic.  
 //! // `MUDDY='D47A372C13DEFED74FD3B9B4C741C355F9CB2C23C43F98ADE2C02FD50CA55C3D' ./target/debug/examples/env`
-//!
-//! fn main() {
+//! # fn main() {
 //!     println!("{}", m!("My highly obfuscated text"));
 //!     println!("{}", "My non obfuscated static str - ripgrep me");
-//! }
+//! # }
 //! ```  
 //!
 //!

--- a/muddy_macros/src/lib.rs
+++ b/muddy_macros/src/lib.rs
@@ -57,6 +57,9 @@ static DEFAULT_ENV: &str = "MUDDY";
 
 pub(crate) type Result<T> = std::result::Result<T, chacha20poly1305::Error>;
 
+// NOTE: All doc tests in this crate are marked with `ignore` since the `muddy_macros` cannot work
+// without the `muddy` crate as a wrapper
+
 #[proc_macro]
 /// Initialization macro that must be called at the crate root.
 /// This sets up the scaffolding for the lazy decryption at runtime.
@@ -74,15 +77,21 @@ pub(crate) type Result<T> = std::result::Result<T, chacha20poly1305::Error>;
 /// ### "env"
 /// If "env" is provided, the key will not be embedded in the binary.
 /// An additional value may be provided to set the env key identifier:
-/// ```rust
-/// muddy_init!("env", "MY_KEY")
+///
+/// ```ignore
+///
+/// muddy_init!("env", "MY_KEY");
 /// ```
 ///
 /// Or at buildtime:  
-/// ```rust
-/// muddy_init!("env")
+///
+/// ```ignore
+///
+/// muddy_init!("env");
+///
+/// // run with `MUDDY='MY_KEY_NAME' cargo b`
+///
 /// ```
-/// `MUDDY='MY_KEY_NAME' cargo b`
 ///
 ///
 pub fn muddy_init(input: TokenStream) -> TokenStream {
@@ -98,7 +107,7 @@ pub fn muddy_init(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// println!("{}", muddy_str!("my text"));
 /// ```
 ///
@@ -117,7 +126,7 @@ pub fn muddy_str(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// println!("{}", m!("my text"));
 /// ```
 ///
@@ -130,7 +139,7 @@ pub fn m(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// #[muddy]
 /// static MY_STR: &str = "my text";
 /// ```
@@ -149,10 +158,10 @@ pub fn muddy(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// muddy_all! {
-/// pub static MY_FIRST_STR: &str = "my text";
-/// static MY_SECOND_STR: &str = "my second text";
+///     pub static MY_FIRST_STR: &str = "my text";
+///     static MY_SECOND_STR: &str = "my second text";
 /// }
 /// ```
 ///


### PR DESCRIPTION
### helps address Issue #4 

* fix doc tests in `muddy`
* ignore all doc tests in `muddy_macros` (which are not functional without the `muddy` crate)
