### PR TITLE
[`chore`] reduce verbosity on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * bump CI/CD checkout@v3 to checkout@v4 (#11)
 * bump --all-- CI/CD checkout@v3 to checkout@v4 and set timeout (#12)
 * add strict clippy lints (#13)
+* reduce output text at build time (#14)
 
 ## 0.2.0
 * Initial published crate version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * bump CI/CD checkout@v3 to checkout@v4 (#11)
 * bump --all-- CI/CD checkout@v3 to checkout@v4 and set timeout (#12)
 * add strict clippy lints (#13)
-* reduce output text at build time (#14)
+* reduce output text at build time (#15)
 
 ## 0.2.0
 * Initial published crate version

--- a/muddy/examples/env.rs
+++ b/muddy/examples/env.rs
@@ -6,7 +6,6 @@
 // Grep the binary for 'obfuscated':
 // $ strings ./target/debug/examples/simple | grep obfuscated
 //
-extern crate muddy;
 
 use muddy::{muddy_all, muddy_init};
 

--- a/muddy/examples/env_custom.rs
+++ b/muddy/examples/env_custom.rs
@@ -6,7 +6,6 @@
 // Grep the binary for 'obfuscated':
 // $ strings ./target/debug/examples/env_custom | grep obfuscated
 //
-extern crate muddy;
 
 use muddy::{muddy_all, muddy_init};
 

--- a/muddy/examples/simple.rs
+++ b/muddy/examples/simple.rs
@@ -1,8 +1,6 @@
 /// Compile this example and grep the binary for 'obfuscated':
 /// $ strings ./target/debug/examples/simple | grep obfuscated
 ///
-extern crate muddy;
-
 use muddy::{m, muddy_init};
 
 muddy_init!();

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -1,4 +1,4 @@
-use crate::{KeyMode, NonObfuscatedText, Result, ENCRYPTION, KEY};
+use crate::{KeyMode, NonObfuscatedText, Result, DEFAULT_ENV, ENCRYPTION, KEY};
 use chacha20poly1305::{
     aead::{Aead, AeadCore, OsRng},
     ChaCha20Poly1305, Nonce,
@@ -38,14 +38,13 @@ pub fn build_obfuscation_mod(
                 let _ = write!(out, "{c:02X}");
                 out
             });
-            let env_name = env.as_ref().map_or("MUDDY", |s| s.as_str());
-            eprintln!("Please, set {env_name} env variable with content:");
+            let env_name = env.as_ref().map_or(DEFAULT_ENV, |s| s.as_str());
             #[cfg(windows)]
             // language=cmd
-            eprintln!(r#"set "{env_name}={key}""#);
+            eprintln!(r#"set {env_name}="{key}""#);
             #[cfg(not(windows))]
             // language=sh
-            eprintln!(r#"{env_name}="{key}""#);
+            eprintln!(r#"{env_name}='{key}'"#);
             build_env_cipher_block(key_ident, cipher_ident, env_name)
         }
     };

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -41,7 +41,7 @@ pub fn build_obfuscation_mod(
             let env_name = env.as_ref().map_or(DEFAULT_ENV, |s| s.as_str());
             #[cfg(windows)]
             // language=cmd
-            eprintln!(r#"set {env_name}="{key}""#);
+            eprintln!(r#"set "{env_name}={key}""#);
             #[cfg(not(windows))]
             // language=sh
             eprintln!(r#"{env_name}='{key}'"#);


### PR DESCRIPTION
* reduce output text at build time

Note for contributor @mrauhu:
I know that we spoke about this issue already a couple of times, so I reached out to a few other devs to ask their opinion about how much/if any output text should be produced by the library. There was a pretty strong preference for not having any output at all. I thought about this for a little bit, and I decided to go with this route. Generally, this type of library should only be used by someone who has read the documentation, and all the instructions should probably be there rather than as actual project output at every build. However, I am planning on making a `cargo-muddy` CLI tool that will automatically obfuscate a rust project (without the need to import the library). And I think that's where all the output would be important (since it will only run once, rather than every build). Thanks again for the help!