### PR TITLE
chore/support different target families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* support multiple target families (#20)
 
 ## 0.2.1
 * add `pull_request.yml` to check for added `CHANGELOG.md` entries on pull requests (#8)

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -72,22 +72,15 @@ pub fn build_obfuscation_mod(
 
 /// Creates the inports for the `muddy_internal` mod
 fn build_obfuscation_imports() -> proc_macro2::TokenStream {
-    #[cfg(unix)]
-    let use_os_str_ext = quote! {
-        use std::os::unix::ffi::OsStrExt;
-    };
-    #[cfg(target_os = "wasi")]
-    let use_os_str_ext = quote! {
-        use std::os::wasi::ffi::OsStrExt;
-    };
-    #[cfg(windows)]
-    let use_os_str_ext = quote! {
-        use std::os::windows::ffi::OsStrExt;
-    };
     quote! {
         use muddy::{GenericArray, KeyInit, Lazy, ChaCha20Poly1305, Key, Aead, U32, Nonce};
         pub use muddy::{LazyStr, FromHex};
-        #use_os_str_ext
+        #[cfg(target_family = "unix")]
+        use std::os::unix::ffi::OsStrExt;
+        #[cfg(target_family = "windows")]
+        use std::os::windows::ffi::OsStrExt;
+        #[cfg(target_family = "wasm")]
+        use std::os::wasi::ffi::OsStrExt;
     }
 }
 


### PR DESCRIPTION
Fixes #19 

* Move build-time target configuration values into caller's code