### PR TITLE
fix/allow using muddy in other proc_macro crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* accept 'MUDDY_KEY' env variable at build to allow wrapping by other crates
 
 ## 0.2.2
 * support multiple target families (#20)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ repository = "https://github.com/orph3usLyre/muddy-waters"
 
 [workspace.dependencies]
 once_cell = "1.19"
+const-hex = "1.14"

--- a/muddy/Cargo.toml
+++ b/muddy/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 repository.workspace = true
 
 [dependencies]
-muddy_macros = { path = "../muddy_macros", version = "0.2"}
+muddy_macros = { path = "../muddy_macros", version = "0.2" }
 once_cell = { workspace = true }
 chacha20poly1305 = "0.10"
-const-hex = "1.11"
+const-hex = { workspace = true }

--- a/muddy_macros/Cargo.toml
+++ b/muddy_macros/Cargo.toml
@@ -23,3 +23,4 @@ once_cell = { workspace = true }
 rand = "0.8"
 aes = "0.8"
 chacha20poly1305 = "0.10"
+const-hex = { workspace = true }

--- a/muddy_macros/src/internal.rs
+++ b/muddy_macros/src/internal.rs
@@ -41,10 +41,10 @@ pub fn build_obfuscation_mod(
             let env_name = env.as_ref().map_or(DEFAULT_ENV, |s| s.as_str());
             #[cfg(windows)]
             // language=cmd
-            eprintln!(r#"set "{env_name}={key}""#);
+            eprintln!(r"set "{env_name}={key}"");
             #[cfg(not(windows))]
             // language=sh
-            eprintln!(r#"{env_name}='{key}'"#);
+            eprintln!(r"{env_name}='{key}'");
             build_env_cipher_block(key_ident, cipher_ident, env_name)
         }
     };

--- a/muddy_macros/src/lib.rs
+++ b/muddy_macros/src/lib.rs
@@ -36,7 +36,17 @@ use meta::{KeyMode, NonObfuscatedText, NonObfuscatedTexts};
 /// Used to generate the key at build time
 ///
 /// Kept separately to embed in the target binary
-pub(crate) static KEY: Lazy<Key> = Lazy::new(|| ChaCha20Poly1305::generate_key(&mut OsRng));
+pub(crate) static KEY: Lazy<Key> = Lazy::new(|| {
+    use const_hex::FromHex;
+    if let Some(muddy_key) = std::env::var_os("MUDDY_KEY") {
+        let Ok(bytes) = <[u8; 32]>::from_hex(muddy_key.as_encoded_bytes()) else {
+            panic!("Can't get bytes from 'MUDDY_KEY' env variable, secret key needs to be a hex string with 64 symbols length.");
+        };
+        Key::clone_from_slice(&bytes)
+    } else {
+        ChaCha20Poly1305::generate_key(&mut OsRng)
+    }
+});
 
 /// Used to generate text encryptions at build time
 pub(crate) static ENCRYPTION: Lazy<ChaCha20Poly1305> = Lazy::new(|| ChaCha20Poly1305::new(&KEY));

--- a/muddy_macros/src/lib.rs
+++ b/muddy_macros/src/lib.rs
@@ -38,14 +38,12 @@ use meta::{KeyMode, NonObfuscatedText, NonObfuscatedTexts};
 /// Kept separately to embed in the target binary
 pub(crate) static KEY: Lazy<Key> = Lazy::new(|| {
     use const_hex::FromHex;
-    if let Some(muddy_key) = std::env::var_os("MUDDY_KEY") {
-        let Ok(bytes) = <[u8; 32]>::from_hex(muddy_key.as_encoded_bytes()) else {
-            panic!("Can't get bytes from 'MUDDY_KEY' env variable, secret key needs to be a hex string with 64 symbols length.");
-        };
-        Key::clone_from_slice(&bytes)
-    } else {
-        ChaCha20Poly1305::generate_key(&mut OsRng)
-    }
+    std::env::var_os("MUDDY_KEY").map_or_else(|| ChaCha20Poly1305::generate_key(&mut OsRng), |muddy_key| {
+         let Ok(bytes) = <[u8; 32]>::from_hex(muddy_key.as_encoded_bytes()) else {
+             panic!("Can't get bytes from 'MUDDY_KEY' env variable, secret key needs to be a hex string with 64 symbols length.");
+         };
+         Key::clone_from_slice(&bytes)
+     })
 });
 
 /// Used to generate text encryptions at build time


### PR DESCRIPTION
Addresses https://github.com/orph3usLyre/muddy-waters/issues/24

This fix allows a user to set the `MUDDY_KEY` variable at build, providing the user a way to "pass down" the key used for the encryption.

[The issue](https://github.com/orph3usLyre/muddy-waters/issues/24) was caused by the fact that if the `muddy_init!()` macro was called in some_crate (i.e. `obscure`), and the `muddy::m!("text")` macro was called in some_proc_macro crate (i.e. `obscure_macro`), the lazily generated `KEY` would be created twice (once by the call to `muddy_init!()`, and once by the call to `muddy::m!()`). Since there is no shared context between the two, two different keys would be generated and the decryption macro would fail.

This fix allows exporting the key before building, which will be taken by all `muddy` contexts.

```
export MUDDY_KEY='B4B45B653DCDE0702D50A3ED5A6C7CE1A4FF510F1FE6431EB8824FF0C8A3F13F'
cargo r
```

Let me know if this can close the issue, @xuxiaocheng0201. If it does, I'll add this to the docs.
