### PR TITLE
feat/v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## 0.3.1
+* correct feature gate for `muddy!()` macro
+
 ## 0.3.0
 * rework muddy internals to use non-allocated deobfuscation
 * remove previous API in favor of `muddy!()` and `muddy_unchecked!()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["muddy"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = ["orph3uslyre"]
 description = "A rust literal string obfuscation library."
 edition = "2021"

--- a/muddy/Cargo.toml
+++ b/muddy/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 repository.workspace = true
 
 [dependencies]
-muddy_macros = { path = "muddy_macros", version = "0.3", default-features = false }
+muddy_macros = { path = "muddy_macros", version = "0.3.1", default-features = false }
 chacha20poly1305 = { version = "0.10", default-features = false }
 aead = { version = "0.5.2", default-features = false, features = ["arrayvec"] }
 arrayvec = { version = "0.7.6", default-features = false }


### PR DESCRIPTION
Correct a feature gate error that required the `env` feature for `muddy!()` 