### PR TITLE
fix/handle multiple different envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* create build-time env-encryption key map to handle multiple possible env variables. 1 env == 1 key.
 
 ## 0.3.2
 * fixes key print output on windows

--- a/muddy/examples/multiple_env.rs
+++ b/muddy/examples/multiple_env.rs
@@ -1,0 +1,31 @@
+use muddy::muddy as m;
+
+// Example for running a program with multiple env variables:
+// `cargo build --example multiple_env` should output:
+//
+// ```
+// MUDDY='564CEBC3BB2AC902EAD4E602A8780F3A474DF62123C85C21F7E75C852F6C5E4E'
+// MY_ENV='5951A941D5A0F92C60F41E8CCA1C71359F4F3A2C9D5596088AFB2DC350FB6308'
+// ```
+//
+// Then run the example:
+// ```
+// MUDDY='564CEBC3BB2AC902EAD4E602A8780F3A474DF62123C85C21F7E75C852F6C5E4E' \
+//  MY_ENV='5951A941D5A0F92C60F41E8CCA1C71359F4F3A2C9D5596088AFB2DC350FB6308' \
+//  cargo run --example multiple_env
+// ```
+//
+//
+
+fn main() {
+    let a = m!("this is a test");
+    let b = m!(env, "another test");
+    let c = m!(env, "third test!");
+    let d = m!(env = "MY_ENV", "fourth test!!!!");
+    let e = m!(env = "MY_ENV", "FIFTH TEST!!!!");
+    eprintln!("{a}");
+    eprintln!("{b}");
+    eprintln!("{c}");
+    eprintln!("{d}");
+    eprintln!("{e}");
+}

--- a/muddy/muddy_macros/src/lib.rs
+++ b/muddy/muddy_macros/src/lib.rs
@@ -138,38 +138,39 @@ impl InPlaceDecrypter {
         let text_len = text.len();
         let env = muddy_input.env.clone();
         // user specified `env`, either custom or default
-        let key = if let Some(env) = env {
-            let mut map = ENV_KEY_MAP.lock().unwrap();
-            // check if env was already placed in map
-            let (key, printed) = if let Some((key, printed)) = map.get(&env) {
-                // if it was, we return the key and indicate if it was already printed for the user
-                (key.clone(), *printed)
-            } else {
-                // if it wasn't, we create the key and insert it in the map.
-                // We haven't used it yet, so we haven't printed it yet
-                let key = ChaCha20Poly1305::generate_key(&mut OsRng);
-                let printed = false;
-                map.insert(env.clone(), (key, printed));
-                (key, printed)
-            };
-            if !printed {
-                let key = key.as_slice().iter().fold(String::new(), |mut out, c| {
-                    let _ = write!(out, "{c:02X}");
-                    out
-                });
-                #[cfg(windows)]
-                // language=cmd
-                eprintln!(r#"set "{env}={key}""#);
-                #[cfg(not(windows))]
-                // language=sh
-                eprintln!(r"{env}='{key}'");
-                // env is printed
-                map.entry(env).and_modify(|(_, printed)| *printed = true);
-            }
-            key
-        } else {
-            ChaCha20Poly1305::generate_key(&mut OsRng)
-        };
+        let key = env.map_or_else(
+            || ChaCha20Poly1305::generate_key(&mut OsRng),
+            |env| {
+                let mut map = ENV_KEY_MAP.lock().unwrap();
+                // check if env was already placed in map
+                let (key, printed) = if let Some((key, printed)) = map.get(&env) {
+                    // if it was, we return the key and indicate if it was already printed for the user
+                    (*key, *printed)
+                } else {
+                    // if it wasn't, we create the key and insert it in the map.
+                    // We haven't used it yet, so we haven't printed it yet
+                    let key = ChaCha20Poly1305::generate_key(&mut OsRng);
+                    let printed = false;
+                    map.insert(env.clone(), (key, printed));
+                    (key, printed)
+                };
+                if !printed {
+                    let key = key.as_slice().iter().fold(String::new(), |mut out, c| {
+                        let _ = write!(out, "{c:02X}");
+                        out
+                    });
+                    #[cfg(windows)]
+                    // language=cmd
+                    eprintln!(r#"set "{env}={key}""#);
+                    #[cfg(not(windows))]
+                    // language=sh
+                    eprintln!(r"{env}='{key}'");
+                    // env is printed
+                    map.entry(env).and_modify(|(_, printed)| *printed = true);
+                }
+                key
+            },
+        );
         let encryption = ChaCha20Poly1305::new(&key);
         let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
         let text = encryption.encrypt(&nonce, text.as_bytes()).unwrap();

--- a/muddy/muddy_macros/src/lib.rs
+++ b/muddy/muddy_macros/src/lib.rs
@@ -13,6 +13,22 @@
 //! outside the context of that crate.
 //!
 
+#[cfg(feature = "env")]
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
+
+#[cfg(feature = "env")]
+type Printed = bool;
+
+#[cfg(feature = "env")]
+static ENV_KEY_MAP: LazyLock<Mutex<HashMap<String, (chacha20poly1305::Key, Printed)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(feature = "env")]
+const DEFAULT_KEY: &str = "MUDDY";
+
 // TODO: look at https://github.com/dtolnay/proc-macro-workshop
 // for crate organization
 use chacha20poly1305::{
@@ -45,7 +61,7 @@ impl syn::parse::Parse for MuddyInput {
             let env = if input.parse::<syn::Token![=]>().is_ok() {
                 input.parse::<syn::LitStr>()?.value()
             } else {
-                "MUDDY".to_string()
+                DEFAULT_KEY.to_string()
             };
             let _ = input.parse::<syn::Token![,]>()?;
             Some(env)
@@ -120,20 +136,41 @@ impl InPlaceDecrypter {
 
         let text = muddy_input.text.value();
         let text_len = text.len();
-        let key = ChaCha20Poly1305::generate_key(&mut OsRng);
+        let env = muddy_input.env.clone();
+        // user specified `env`, either custom or default
+        let key = if let Some(env) = env {
+            let mut map = ENV_KEY_MAP.lock().unwrap();
+            // check if env was already placed in map
+            let (key, printed) = if let Some((key, printed)) = map.get(&env) {
+                // if it was, we return the key and indicate if it was already printed for the user
+                (key.clone(), *printed)
+            } else {
+                // if it wasn't, we create the key and insert it in the map.
+                // We haven't used it yet, so we haven't printed it yet
+                let key = ChaCha20Poly1305::generate_key(&mut OsRng);
+                let printed = false;
+                map.insert(env.clone(), (key, printed));
+                (key, printed)
+            };
+            if !printed {
+                let key = key.as_slice().iter().fold(String::new(), |mut out, c| {
+                    let _ = write!(out, "{c:02X}");
+                    out
+                });
+                #[cfg(windows)]
+                // language=cmd
+                eprintln!(r#"set "{env}={key}""#);
+                #[cfg(not(windows))]
+                // language=sh
+                eprintln!(r"{env}='{key}'");
+                // env is printed
+                map.entry(env).and_modify(|(_, printed)| *printed = true);
+            }
+            key
+        } else {
+            ChaCha20Poly1305::generate_key(&mut OsRng)
+        };
         let encryption = ChaCha20Poly1305::new(&key);
-        if let Some(env) = &muddy_input.env {
-            let key = key.as_slice().iter().fold(String::new(), |mut out, c| {
-                let _ = write!(out, "{c:02X}");
-                out
-            });
-            #[cfg(windows)]
-            // language=cmd
-            eprintln!(r#"set "{env}={key}""#);
-            #[cfg(not(windows))]
-            // language=sh
-            eprintln!(r"{env}='{key}'");
-        }
         let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
         let text = encryption.encrypt(&nonce, text.as_bytes()).unwrap();
         Self {

--- a/muddy/src/lib.rs
+++ b/muddy/src/lib.rs
@@ -31,7 +31,7 @@
 //! >
 //! > `cargo b --example simple`  
 //! >
-//! > `strings ./target/debug/examples/simple | grep obfuscated`    
+//! > `strings ./target/debug/examples/simple | grep obfuscated`\\
 //! > Only the second nonobfuscated line should appear.
 //! >  
 //!   


### PR DESCRIPTION
Addresses #33 :
Consolidates env keys into a build time map. This affects both the default env variable (`MUDDY=`, used when `env` is passed with no identifier, i.e.: `muddy!(env, "some text")`), as well as any custom variables:
```
let a = muddy!(env = "MY_ENV", "some text");
let b = muddy!(env = "MY_ENV", "other text");
```

Practically, this means `1 env == 1 key`
